### PR TITLE
fix: set span attribute to pathway hash

### DIFF
--- a/lib/datadog/data_streams/context.ex
+++ b/lib/datadog/data_streams/context.ex
@@ -16,7 +16,6 @@ defmodule Datadog.DataStreams.Context do
   """
 
   @context_key "dd-datastreams"
-  @hash "pathway.hash"
 
   alias Datadog.DataStreams.{Pathway, Tags}
 
@@ -36,7 +35,6 @@ defmodule Datadog.DataStreams.Context do
   @spec set(Pathway.t()) :: Pathway.t()
   def set(%Pathway{} = pathway) do
     OpenTelemetry.Ctx.set_value(@context_key, pathway)
-    OpenTelemetry.Ctx.set_value(@hash, pathway.hash)
     pathway
   end
 


### PR DESCRIPTION
I realized I was setting the otel context instead of the span attribute. This should link Open Telemetry Kafka processing and producing APM traces with data stream pathways. It follows a closed PR in the data-streams-go library, but was confirmed on a call with Datadog.