### PR TITLE
fix: defensive code around container logic

### DIFF
--- a/lib/datadog/data_streams/container.ex
+++ b/lib/datadog/data_streams/container.ex
@@ -49,7 +49,7 @@ defmodule Datadog.DataStreams.Container do
     file
     |> File.stream!()
     |> parse_container_id()
-  catch
+  rescue
     _ -> nil
   end
 
@@ -61,7 +61,7 @@ defmodule Datadog.DataStreams.Container do
     |> Stream.map(&parse_line/1)
     |> Stream.filter(fn value -> not is_nil(value) end)
     |> Enum.at(0)
-  catch
+  rescue
     _ -> nil
   end
 

--- a/test/datadog/data_streams/container_test.exs
+++ b/test/datadog/data_streams/container_test.exs
@@ -162,4 +162,8 @@ defmodule Datadog.DataStreams.ContainerTest do
 
     assert ^cid = Container.read_container_id(file_path)
   end
+
+  test "read_container_id/1 does not fail when file does not exist" do
+    refute Container.read_container_id("/does/not/exist/ohpleasedontbreakmytests")
+  end
 end


### PR DESCRIPTION
`catch` vs `rescue` is still one of the Elixir pitfalls I wish was handled better.

Fixes this logic breaking when not in a container and crashing the application.