### PR TITLE
feat: allow tracking kafka produce and consume offsets

### DIFF
--- a/lib/datadog/data_streams/aggregator/bucket.ex
+++ b/lib/datadog/data_streams/aggregator/bucket.ex
@@ -7,22 +7,17 @@ defmodule Datadog.DataStreams.Aggregator.Bucket do
   @bucket_duration 10 * 1_000 * 1_000 * 1_000
 
   defstruct groups: %{},
-            latest_commit_offsets: %{},
-            latest_produce_offsets: %{},
+            latest_commit_offsets: [],
+            latest_produce_offsets: [],
             start: 0,
             duration: @bucket_duration
 
   @type t :: %__MODULE__{
           groups: %{non_neg_integer() => Aggregator.Group.t()},
-          latest_commit_offsets: %{non_neg_integer() => non_neg_integer()},
-          latest_produce_offsets: %{partition_key() => non_neg_integer()},
+          latest_commit_offsets: [Aggregator.Offset.t()],
+          latest_produce_offsets: [Aggregator.Offset.t()],
           start: non_neg_integer(),
           duration: non_neg_integer()
-        }
-
-  @type partition_key :: %{
-          partition: non_neg_integer(),
-          topic: String.t()
         }
 
   @spec align_timestamp(non_neg_integer()) :: non_neg_integer()

--- a/lib/datadog/data_streams/aggregator/offset.ex
+++ b/lib/datadog/data_streams/aggregator/offset.ex
@@ -1,0 +1,49 @@
+defmodule Datadog.DataStreams.Aggregator.Offset do
+  @moduledoc false
+
+  defstruct offset: 0,
+            timestamp: 0,
+            type: :commit,
+            tags: %{}
+
+  @type type :: :commit | :produce
+
+  @type t :: %__MODULE__{
+          offset: integer(),
+          timestamp: non_neg_integer(),
+          type: type(),
+          tags: %{String.t() => any()}
+        }
+
+  @doc """
+  Creates a new offset map with the given offset and what ever options
+  given.
+  """
+  @spec new(type(), integer(), non_neg_integer(), Keyword.t()) :: t()
+  def new(type, offset, timestamp, opts \\ []) do
+    %__MODULE__{
+      offset: offset,
+      timestamp: timestamp,
+      type: type,
+      tags: Map.new(opts)
+    }
+  end
+
+  @doc """
+  Updates an existing `#{__MODULE__}` where all properties except the
+  `offset` match. If no matching one is found, we create a new one.
+  """
+  @spec upsert([t()], t()) :: [t()]
+  def upsert(offsets, %{tags: upsert_tags} = upsert_offset) do
+    matching_index =
+      Enum.find(offsets, fn %{tags: tags} ->
+        match?(^tags, upsert_tags)
+      end)
+
+    if is_nil(matching_index) do
+      offsets ++ [upsert_offset]
+    else
+      List.replace_at(offsets, matching_index, upsert_offset)
+    end
+  end
+end

--- a/lib/datadog/data_streams/aggregator/offset.ex
+++ b/lib/datadog/data_streams/aggregator/offset.ex
@@ -16,8 +16,7 @@ defmodule Datadog.DataStreams.Aggregator.Offset do
         }
 
   @doc """
-  Creates a new offset map with the given offset and what ever options
-  given.
+  Creates a new offset map with the given offset and options
   """
   @spec new(type(), integer(), non_neg_integer(), Keyword.t()) :: t()
   def new(type, offset, timestamp, opts \\ []) do

--- a/lib/datadog/data_streams/aggregator/offset.ex
+++ b/lib/datadog/data_streams/aggregator/offset.ex
@@ -30,7 +30,7 @@ defmodule Datadog.DataStreams.Aggregator.Offset do
 
   @doc """
   Updates an existing `#{__MODULE__}` where all properties except the
-  `offset` match. If no matching one is found, we create a new one.
+  `offset` match. If no match is found, we create a new one.
   """
   @spec upsert([t()], t()) :: [t()]
   def upsert(offsets, %{tags: upsert_tags} = upsert_offset) do

--- a/lib/datadog/data_streams/payload/backlog.ex
+++ b/lib/datadog/data_streams/payload/backlog.ex
@@ -1,7 +1,7 @@
 defmodule Datadog.DataStreams.Payload.Backlog do
   @moduledoc false
 
-  alias Datadog.DataStreams.Tags
+  alias Datadog.DataStreams.{Aggregator, Tags}
 
   defstruct tags: [],
             value: 0
@@ -10,10 +10,24 @@ defmodule Datadog.DataStreams.Payload.Backlog do
           tags: Tags.encoded(),
           value: non_neg_integer()
         }
+
+  def new(%Aggregator.Offset{offset: offset, tags: tags}) do
+    %__MODULE__{
+      tags: tags |> Tags.parse() |> Tags.encode(),
+      value: offset
+    }
+  end
 end
 
 defimpl Msgpax.Packer, for: Datadog.DataStreams.Payload.Backlog do
-  def pack(_data) do
-    []
+  def pack(data) do
+    [
+      # Tags
+      [0x82, 0xA4, 0x54, 0x61, 0x67, 0x73],
+      Msgpax.Packer.pack(data.tags),
+      # Value
+      [0xA5, 0x56, 0x61, 0x6C, 0x75, 0x65],
+      Msgpax.Packer.pack(data.value)
+    ]
   end
 end

--- a/lib/datadog/data_streams/payload/backlog.ex
+++ b/lib/datadog/data_streams/payload/backlog.ex
@@ -11,6 +11,10 @@ defmodule Datadog.DataStreams.Payload.Backlog do
           value: non_neg_integer()
         }
 
+  @doc """
+  Creates a new backlog struct from an aggregator offset.
+  """
+  @spec new(Aggregator.Offset.t()) :: t()
   def new(%Aggregator.Offset{offset: offset, tags: tags}) do
     %__MODULE__{
       tags: tags |> Tags.parse() |> Tags.encode(),

--- a/lib/datadog/data_streams/payload/bucket.ex
+++ b/lib/datadog/data_streams/payload/bucket.ex
@@ -26,7 +26,10 @@ defmodule Datadog.DataStreams.Payload.Bucket do
     %__MODULE__{
       start: bucket.start,
       duration: bucket.duration,
-      stats: bucket.groups |> Map.values() |> Enum.map(&Payload.Point.new(&1, timestamp_type))
+      stats: bucket.groups |> Map.values() |> Enum.map(&Payload.Point.new(&1, timestamp_type)),
+      backlogs:
+        Enum.map(bucket.latest_produce_offsets, &Payload.Backlog.new/1) ++
+          Enum.map(bucket.latest_commit_offsets, &Payload.Backlog.new/1)
     }
   end
 end


### PR DESCRIPTION
This was the one remaining feature from the golang library that I haven't ported yet. Now it's done. It allows tracking Kafka offsets. Datadog uses this to detect lag and consumers that are offline and not reporting.

After every publish, we push the last offset to Datadog. After every consume, we push the last read offset to Datadog. It can then calculate the offset and alert us on issues.